### PR TITLE
Add docs badge to README

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -2,6 +2,7 @@
 {<img src="https://travis-ci.org/Muriel-Salvan/rails-ajax.png?branch=master" />}[https://travis-ci.org/Muriel-Salvan/rails-ajax]
 {<img src="https://codeclimate.com/github/Muriel-Salvan/rails-ajax.png" />}[https://codeclimate.com/github/Muriel-Salvan/rails-ajax]
 {<img src="https://codeclimate.com/github/Muriel-Salvan/rails-ajax/coverage.png" />}[https://codeclimate.com/github/Muriel-Salvan/rails-ajax]
+{<img src="http://inch-pages.github.io/github/Muriel-Salvan/rails-ajax.png" alt="Inline docs" />}[http://inch-pages.github.io/github/Muriel-Salvan/rails-ajax]
 {<img src="https://gemnasium.com/Muriel-Salvan/rails-ajax.svg" alt="Dependency Status" />}[https://gemnasium.com/Muriel-Salvan/rails-ajax]
 
 = Rails-Ajax


### PR DESCRIPTION
I just added the badge you requested to your README: ![Inline docs](http://inch-pages.github.io/github/Muriel-Salvan/rails-ajax.png)

Your status page for this project is http://inch-pages.github.io/github/Muriel-Salvan/rails-ajax

If you have any questions/suggestions, just post them here or create a new issue in the Inch Pages project!
